### PR TITLE
Basic speed diff indicator

### DIFF
--- a/src/main/kotlin/polina4096/resquake/ReSquakeConfig.kt
+++ b/src/main/kotlin/polina4096/resquake/ReSquakeConfig.kt
@@ -26,6 +26,7 @@ class ReSquakeConfig(@Transient var path: Path? = null) {
 
     // Speed indicator
     var speedDeltaIndicatorEnabled : Boolean = DEFAULT_SPEED_DELTA_INDICATOR_ENABLED
+    var speedDiffIndicatorEnabled  : Boolean = DEFAULT_SPEED_DIFF_INDICATOR_ENABLED
     var speedDeltaThreshold        : Double  = DEFAULT_SPEED_DELTA_THRESHOLD
     var speedGainColor             : Int     = SPEED_GAIN_COLOR      . rgb
     var speedLossColor             : Int     = SPEED_LOSS_COLOR      . rgb
@@ -65,6 +66,7 @@ class ReSquakeConfig(@Transient var path: Path? = null) {
 
         // Speed indicator
         const val DEFAULT_SPEED_DELTA_INDICATOR_ENABLED = true
+        const val DEFAULT_SPEED_DIFF_INDICATOR_ENABLED  = true
         const val DEFAULT_SPEED_DELTA_THRESHOLD         = 6.0
       /* s */ val SPEED_GAIN_COLOR                      = Color(0xFF_00FF00.toInt())
       /* a */ val SPEED_LOSS_COLOR                      = Color(0xFF_FF0000.toInt())

--- a/src/main/kotlin/polina4096/resquake/ReSquakeConfigScreen.kt
+++ b/src/main/kotlin/polina4096/resquake/ReSquakeConfigScreen.kt
@@ -102,6 +102,16 @@ fun generateConfigScreen(parent: Screen?): Screen
                     .build())
 
                 .option(
+                    Option.createBuilder<Boolean>()
+                    .name(Text.of("Difference indicator"))
+                    .description(OptionDescription.of(Text.of("Enables/disables the display of +/- speed from last hop")))
+                    .binding(ReSquakeConfig.DEFAULT_SPEED_DIFF_INDICATOR_ENABLED,
+                             { ReSquakeMod.config.speedDiffIndicatorEnabled },
+                             { ReSquakeMod.config.speedDiffIndicatorEnabled = it })
+                    .controller(BooleanControllerBuilder::create)
+                    .build())
+
+                .option(
                     Option.createBuilder<Double>()
                     .name(Text.of("Speed delta threshold"))
                     .description(OptionDescription.of(Text.of("Minimum speed needed for indicator to appear")))

--- a/src/main/kotlin/polina4096/resquake/ReSquakeModClient.kt
+++ b/src/main/kotlin/polina4096/resquake/ReSquakeModClient.kt
@@ -40,12 +40,14 @@ object ReSquakeModClient : ClientModInitializer {
         val mc = MinecraftClient.getInstance()
         HudRenderCallback.EVENT.register { ctx: DrawContext, _: Float ->
             val speed = ReSquakePlayer.currentSpeed * 20
+            val speedDifference = speed - (ReSquakePlayer.previousSpeed * 20)
             if (!ReSquakeMod.config.speedDeltaIndicatorEnabled || !ReSquakePlayer.jumping || ReSquakePlayer.swimming || speed < ReSquakeMod.config.speedDeltaThreshold)
                 return@register
 
             val posX = mc.window.scaledWidth  / 2.0f
             val posY = mc.window.scaledHeight / 2.0f
             val text = "%.2f".format(speed)
+
             val centerOffset = mc.textRenderer.getWidth(text) / 2.0f
 
             val delta = ReSquakePlayer.currentSpeed.compareTo(ReSquakePlayer.previousSpeed)
@@ -56,6 +58,10 @@ object ReSquakeModClient : ClientModInitializer {
             }
 
             ctx.drawTextWithShadow(mc.textRenderer, text, (posX - centerOffset).roundToInt(), (posY + 15).roundToInt(), color)
+            if (ReSquakeMod.config.speedDiffIndicatorEnabled) {
+                val differenceText = "%.2f".format(speedDifference)
+                ctx.drawTextWithShadow(mc.textRenderer, differenceText, (posX - centerOffset).roundToInt(), (posY + 25).roundToInt(), color)
+            }
         }
     }
 }


### PR DESCRIPTION
Adds another indicator below the speed indicator. Shows the speed difference between this hop and the last hop (as opposed to just the blocks/sec you were at when you hopped), and adds a config option to disable it.

This is my very first contribution to a Minecraft mod, so please point out any issues or anything I should have done differently, so I can learn from my mistakes.